### PR TITLE
BUGFIX: Prevent EnumType() accessor vs EnumType.NULL_VALUE name clash

### DIFF
--- a/src/main/java/sbe/generation/csharp/CSharpGenerator.java
+++ b/src/main/java/sbe/generation/csharp/CSharpGenerator.java
@@ -2328,7 +2328,7 @@ public class CSharpGenerator implements CodeGenerator {
                             indent + "    }\n\n",
                     enumName,
                     propertyName,
-                    generateEnumFieldNotPresentCondition(token.version(), enumName, indent),
+                    generateEnumFieldNotPresentCondition(token.version(), namespace(), enumName, indent),
                     enumName,
                     generateGet(token.encoding().primitiveType(), "_offset + " + token.offset(), byteOrderStr)
             );
@@ -2337,15 +2337,18 @@ public class CSharpGenerator implements CodeGenerator {
 
     private CharSequence generateEnumFieldNotPresentCondition(
             final int sinceVersion,
+            final String namespace,
             final String enumName,
-            final String indent) {
+            final String indent
+    ) {
         if (0 == sinceVersion) {
             return "";
         }
 
         return String.format(
-                indent + INDENT + INDENT + "if (_actingVersion < %d) return %s.NULL_VALUE;\n\n",
+                indent + INDENT + INDENT + "if (_actingVersion < %d) return %s.%s.NULL_VALUE;\n\n",
                 sinceVersion,
+                namespace,
                 enumName);
     }
 


### PR DESCRIPTION
BUGFIX: Prevent EnumType() accessor vs EnumType.NULL_VALUE name clash when sinceVersion used.

C# uses an upper case notation for both method names and types. When the same name is used for the accessor and the type, it causes the following  name clash.

```
public SomeEnum SomeEnum()
    {
        if (_actingVersion < 1) return SomeEnum.NULL_VALUE;

        return (SomeEnum)unchecked((sbyte)_buffer.GetByte(_offset + 29));
    }
```

This is a compilation error.

The solution is to use a fully qualified name in this case.

```
public SomeEnum SomeEnum()
    {
        if (_actingVersion < 1) return Com.Example.SomeEnum.NULL_VALUE;

        return (SomeEnum)unchecked((sbyte)_buffer.GetByte(_offset + 29));
    }
```

This fixed the problem.